### PR TITLE
爆発を受けたときに移動する方向に向く処理

### DIFF
--- a/src/Assets/Prefabs/Player/Player_CinemaChine.prefab
+++ b/src/Assets/Prefabs/Player/Player_CinemaChine.prefab
@@ -75,10 +75,12 @@ GameObject:
   - component: {fileID: 8253266369385063216}
   - component: {fileID: 4887803152705769510}
   - component: {fileID: 2364280095217102194}
+  - component: {fileID: 6567396642241255447}
   - component: {fileID: 4393592498401854528}
   - component: {fileID: 568083875313027701}
   - component: {fileID: 2579846102088291873}
   - component: {fileID: 7834042539771189614}
+  - component: {fileID: 424469328706394918}
   m_Layer: 3
   m_Name: Player_CinemaChine
   m_TagString: Player
@@ -102,6 +104,7 @@ Transform:
   - {fileID: 6652671843328375814}
   - {fileID: 3316287421034294428}
   - {fileID: 1843077072586268663}
+  - {fileID: 1692146832237582446}
   - {fileID: 154745808761288618}
   - {fileID: 7878180206275059215}
   m_Father: {fileID: 0}
@@ -121,7 +124,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3640815705827342858}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -206,6 +209,20 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!114 &6567396642241255447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3640815705827342858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e88081868843fd0458abf596d48e98e0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PlayerAnimator: {fileID: 424469328706394918}
+  playerRigidbody: {fileID: 2364280095217102194}
 --- !u!114 &4393592498401854528
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -218,7 +235,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c680cc8185fd5d5438afcfa938578e02, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Bomb: {fileID: 475757326369631188, guid: eea6cd15a02f5524da1ef6d74e962ece, type: 3}
+  Bomb: {fileID: 3672593736015811124, guid: 05c3f7b033a51d24eb1ecf500d2291d8, type: 3}
   ThrowBombSpawnPosition: {fileID: 4250198401329017485}
   JumpBombSpawnPosition: {fileID: 3111844019099697175}
   BrinkBombSpawnPosition: {fileID: 1714432846268466497}
@@ -228,6 +245,7 @@ MonoBehaviour:
   InputFlag: 0
   FullautoEnable: 0
   BombShotInterval: 8
+  playerAnimation: {fileID: 6567396642241255447}
 --- !u!114 &568083875313027701
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,6 +287,28 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   PlayerBodyTransform: {fileID: 7878180206275059215}
   PlayerModelTransform: {fileID: 154745808761288618}
+  LimitModelVertical: 0.9
+--- !u!95 &424469328706394918
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3640815705827342858}
+  m_Enabled: 1
+  m_Avatar: {fileID: 9000000, guid: c75549011c66d4e428f8ed09cc8383cd, type: 3}
+  m_Controller: {fileID: 9100000, guid: a33e7d6e12092344da49b18bc4d9dbba, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &4250198401329017485
 GameObject:
   m_ObjectHideFlags: 0
@@ -362,3 +402,147 @@ Transform:
   m_Children: []
   m_Father: {fileID: 8050834733684318280}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &4132224584595796817
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8050834733684318280}
+    m_Modifications:
+    - target: {fileID: 1513172763982559615, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1513172763982559615, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_TagString
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 2035242413172566479, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2035242413172566479, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_WarningMessage
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3938681774857597651, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_UseGravity
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3938681774857597651, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_Constraints
+      value: 126
+      objectReference: {fileID: 0}
+    - target: {fileID: 3938681774857597651, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_ImplicitCom
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3938681774857597651, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_ImplicitTensor
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5668565427591895411, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5668565427591895411, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: playerBomb
+      value: 
+      objectReference: {fileID: 4393592498401854528}
+    - target: {fileID: 5668565427591895411, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: playerRigidbody
+      value: 
+      objectReference: {fileID: 2364280095217102194}
+    - target: {fileID: 8378245432249872070, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8770046810776133087, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_Name
+      value: AnimationTest
+      objectReference: {fileID: 0}
+    - target: {fileID: 8770046810776133087, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8770046810776133087, guid: 43c018ef8562133409cd265e8720adaa,
+        type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 43c018ef8562133409cd265e8720adaa, type: 3}
+--- !u!4 &1692146832237582446 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3324547996391385919, guid: 43c018ef8562133409cd265e8720adaa,
+    type: 3}
+  m_PrefabInstance: {fileID: 4132224584595796817}
+  m_PrefabAsset: {fileID: 0}

--- a/src/Assets/Scripts/Bomb effects.cs
+++ b/src/Assets/Scripts/Bomb effects.cs
@@ -142,6 +142,12 @@ public class Bombeffects : MonoBehaviour
             }
             else if (P[i].tag == "Player")
             {
+                if (P[i].TryGetComponent<PlayerRotateAction>(out PlayerRotateAction act))
+                {
+                    Debug.Log("try get component PlayerRotateAction");
+                    act.RotateToExplosion(P[i].transform.position - this.transform.position);
+                }
+
                 if (P[i].TryGetComponent<Animator>(out Animator animator))
                 {
                     Debug.Log("try get component Animator");

--- a/src/Assets/Scripts/Masa script/Input/PlayerRotateAction.cs
+++ b/src/Assets/Scripts/Masa script/Input/PlayerRotateAction.cs
@@ -10,6 +10,8 @@ public class PlayerRotateAction : MonoBehaviour
     [SerializeField] Transform PlayerBodyTransform; // プレイヤー本体のTransform（瞬間回転用）
     [SerializeField] Transform PlayerModelTransform; // プレイヤーモデルのTransform（補間回転用）
 
+    [SerializeField, Range(0f, 1f)] float LimitModelVertical = 0.9f;
+
     /// <summary>
     /// 回転補間用のデータ構造
     /// Slerpアニメーションの各フレームの情報を格納
@@ -62,6 +64,36 @@ public class PlayerRotateAction : MonoBehaviour
             quaternionSlape.Look = lookRotation; // 目標回転
             quaternionSlape.clamp = i / slapeFlame; // 補間率（0→1まで段階的に）
             slapesQueue.Enqueue(quaternionSlape); // キューに追加
+        }
+    }
+
+    /// <summary>
+    /// 爆発したベクトル方向にモデルを回転する
+    /// </summary>
+    /// <param name="explosionDir">爆発位置 → 自分の方向ベクトル</param>
+    public void RotateToExplosion(Vector3 explosionDir)
+    {
+        Vector3 dir = explosionDir.normalized;
+
+        // 一定以上の上下方向成分がある場合は回転をスキップ
+        // 具体例:90%以上が上下方向ならスキップ
+        if (Mathf.Abs(dir.y) > LimitModelVertical)
+        {
+            // 爆風がほぼ真上・真下から来ている → 回転をスキップ
+            return;
+        }
+
+        // 回転補間キューを初期化
+        slapesQueue = new Queue<QuaternionSlape>();
+
+        // 水平方向だけを考慮（Y軸の高さは無視）
+        dir.y = 0f;
+
+        // 向きを回転として適用
+        if (dir.sqrMagnitude > 0.001f)
+        {
+            Quaternion rot = Quaternion.LookRotation(dir);
+            PlayerModelTransform.rotation = rot;
         }
     }
 


### PR DESCRIPTION
## 概要
*Playerが動く平面方向(y軸)にモデルを回転させる処理*

## 変更点
- *Bombeffectsに処理追加*
- *PlayerRotateActionに関数追加*
- *Player_CinemaChineを更新*

