### PR TITLE
Add/audio spectrum

### DIFF
--- a/src/Assets/Scripts/Sound.meta
+++ b/src/Assets/Scripts/Sound.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d89af16f368f8c4e9cc1b77e93b4280
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Scripts/Sound/AudioCulcurator.cs
+++ b/src/Assets/Scripts/Sound/AudioCulcurator.cs
@@ -34,11 +34,6 @@ public class AudioCulcurator : MonoBehaviour
         }
     }
 
-    void Update()
-    {
-        
-    }
-
     /// <summary>
     /// FFT Resolusion ‚Ì’l‚ð•Ô‚·
     /// </summary>

--- a/src/Assets/Scripts/Sound/AudioCulcurator.cs
+++ b/src/Assets/Scripts/Sound/AudioCulcurator.cs
@@ -16,7 +16,6 @@ public class AudioCulcurator : MonoBehaviour
     private AudioClip[] clips = default;
 
     // オーディオデータ用
-    // private float[,] data = default;
     private List<float[]> data = new List<float[]>();
 
     void Start()
@@ -40,12 +39,21 @@ public class AudioCulcurator : MonoBehaviour
         
     }
 
+    /// <summary>
+    /// FFT Resolusion の値を返す
+    /// </summary>
+    /// <returns>int FFT_resolusion</returns>
     public int GetFFTResolusion()
     {
         return (int)fft_res;
     }
 
-    public void GetData(ref float[] target, int dataLength)
+    /// <summary>
+    /// 現在の時間から決められた長さ分の波形データを渡す関数
+    /// </summary>
+    /// <param name="target">この配列に値が格納される、長さは dataLength</param>
+    /// <param name="dataLength">配列の長さ</param>
+    public void GetWaveData(ref float[] target, int dataLength)
     {
         target = new float[dataLength];
 
@@ -63,6 +71,10 @@ public class AudioCulcurator : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// 現在から0.1秒後までの音量の和を返す関数
+    /// </summary>
+    /// <returns>float 音量</returns>
     public float GetCurrentData()
     {
         float res = 0;
@@ -90,6 +102,10 @@ public class AudioCulcurator : MonoBehaviour
         return res;
     }
 
+    /// <summary>
+    /// 現在のスペクトルを渡す関数
+    /// </summary>
+    /// <param name="target">この配列に値が格納される、長さは fft_res</param>
     public void GetSpectrum(ref float[] target)
     {
         float[] spec = new float[(int)fft_res];

--- a/src/Assets/Scripts/Sound/AudioCulcurator.cs
+++ b/src/Assets/Scripts/Sound/AudioCulcurator.cs
@@ -17,10 +17,7 @@ public class AudioCulcurator : MonoBehaviour
 
     // オーディオデータ用
     // private float[,] data = default;
-    private List<float[]> data = default;
-
-    // スペクトラム用
-    private List<float[]> spectrum = default;
+    private List<float[]> data = new List<float[]>();
 
     void Start()
     {
@@ -35,11 +32,6 @@ public class AudioCulcurator : MonoBehaviour
             // data の初期化
             data.Add(new float[clips[i].channels * clips[i].samples]);
             clips[i].GetData(data[i], 0);
-
-            Debug.Log(data[i][0]);
-
-            // spectrum の初期化
-            spectrum.Add(new float[(int)fft_res]);
         }
     }
 

--- a/src/Assets/Scripts/Sound/AudioCulcurator.cs
+++ b/src/Assets/Scripts/Sound/AudioCulcurator.cs
@@ -1,0 +1,118 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AudioCulcurator : MonoBehaviour
+{
+    enum FFT_resolusion
+    {
+        _8192 = 8192, _4096 = 4096, _2048 = 2048, _1024 = 1024, _512 = 512, _256 = 256, _128 = 128, _64 = 64
+    }
+
+    // アタッチされた音源のデータを返すクラス
+    [SerializeField] List<AudioSource> sources;
+    [SerializeField] FFT_resolusion fft_res = FFT_resolusion._256;
+
+    private AudioClip[] clips = default;
+
+    // オーディオデータ用
+    // private float[,] data = default;
+    private List<float[]> data = default;
+
+    // スペクトラム用
+    private List<float[]> spectrum = default;
+
+    void Start()
+    {
+        clips = new AudioClip[sources.Count];
+        for(int i = 0; i < sources.Count; i++)
+        {
+            clips[i] = sources[i].clip;
+        }
+
+        for(int i = 0; i < sources.Count; i++)
+        {
+            // data の初期化
+            data.Add(new float[clips[i].channels * clips[i].samples]);
+            clips[i].GetData(data[i], 0);
+
+            Debug.Log(data[i][0]);
+
+            // spectrum の初期化
+            spectrum.Add(new float[(int)fft_res]);
+        }
+    }
+
+    void Update()
+    {
+        
+    }
+
+    public int GetFFTResolusion()
+    {
+        return (int)fft_res;
+    }
+
+    public void GetData(ref float[] target, int dataLength)
+    {
+        target = new float[dataLength];
+
+        for(int i = 0; i < sources.Count; i++)
+        {
+            float strength = sources[i].mute == true ? 0 : 1;
+            strength *= sources[i].volume;
+
+            int startIndex = sources[i].timeSamples;
+
+            for(int j = 0; j < dataLength; j++)
+            {
+                target[j] += data[i][startIndex + j] * strength / sources.Count;
+            }
+        }
+    }
+
+    public float GetCurrentData()
+    {
+        float res = 0;
+
+        for(int i = 0; i < sources.Count; i++)
+        {
+            int currentIndex = sources[i].timeSamples;
+            int sampleNum = clips[i].frequency / 10;
+            sampleNum = 1;
+            float sum = 0;
+
+            float strength = sources[i].mute == true ? 0 : 1;
+            strength *= sources[i].volume;
+
+            if (strength <= 0.01f) continue; // 十分に小さかったらスキップ
+
+            for(int j = 0; j < sampleNum; j++)
+            {
+                sum += Mathf.Abs(data[i][currentIndex + j]);
+            }
+
+            res += sum * strength;
+        }
+
+        return res;
+    }
+
+    public void GetSpectrum(ref float[] target)
+    {
+        float[] spec = new float[(int)fft_res];
+        target = new float[(int)fft_res];
+        for(int i = 0; i < sources.Count; i++)
+        {
+            float strength = sources[i].mute == true ? 0 : 1;
+            strength *= sources[i].volume;
+
+            sources[i].GetSpectrumData(spec, 0, FFTWindow.Rectangular);
+
+            for(int j = 0; j < (int)fft_res; j++)
+            {
+                target[j] += spec[j] * strength / sources.Count;
+            }
+        }
+    }
+}

--- a/src/Assets/Scripts/Sound/AudioCulcurator.cs.meta
+++ b/src/Assets/Scripts/Sound/AudioCulcurator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28e5556164c140e4191dc981de871e51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Scripts/Sound/AudioLineRender.cs
+++ b/src/Assets/Scripts/Sound/AudioLineRender.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AudioLineRender : MonoBehaviour
+{
+    // LineRenderer を直線状に描画する
+    [SerializeField] private AudioCulcurator AC;
+    [SerializeField] private LineRenderer line;
+
+    [SerializeField] private float lineLength = 20.0f;
+    [SerializeField] private float height = 40.0f;
+    [SerializeField, Range(0.0f, 100.0f)] private float visible = 100;
+
+    private float[] spectrum = null; // spectrum のデータを受け取る配列
+    private Vector3[] points = null; // line renderer の頂点位置
+    private float xStep; // x座標の間隔
+
+    void Start()
+    {
+        // local position で指定する
+        line.useWorldSpace = false;
+        line.positionCount = AC.GetFFTResolusion();
+
+        points = new Vector3[AC.GetFFTResolusion()];
+        xStep = lineLength / AC.GetFFTResolusion();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        AC.GetSpectrum(ref spectrum);
+
+        for(int i = 0; i < points.Length; i++)
+        {
+            int isVisible = i <= AC.GetFFTResolusion()*visible/100 ? 1 : 0;
+
+            float x = xStep * i;
+            float y = spectrum[i] * height * isVisible;
+            points[i] = new Vector3(x, y, 0);
+        }
+
+        line.SetPositions(points);
+    }
+}

--- a/src/Assets/Scripts/Sound/AudioLineRender.cs
+++ b/src/Assets/Scripts/Sound/AudioLineRender.cs
@@ -26,7 +26,6 @@ public class AudioLineRender : MonoBehaviour
         xStep = lineLength / AC.GetFFTResolusion();
     }
 
-    // Update is called once per frame
     void Update()
     {
         AC.GetSpectrum(ref spectrum);

--- a/src/Assets/Scripts/Sound/AudioLineRender.cs.meta
+++ b/src/Assets/Scripts/Sound/AudioLineRender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57af0d1cd4349af40be46d14257ee14e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Scripts/Sound/AudioVolumeScaler.cs
+++ b/src/Assets/Scripts/Sound/AudioVolumeScaler.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AudioVolumeScaler : MonoBehaviour
+{
+    // ‰¹—Ê‚É‰‚¶‚ÄƒXƒP[ƒ‹‚ğ•Ï‰»‚³‚¹‚é
+    [SerializeField] private AudioCulcurator AC;
+
+    void Start()
+    {
+        
+    }
+
+    void Update()
+    {
+        Debug.Log(AC.GetCurrentData().ToString());
+    }
+}

--- a/src/Assets/Scripts/Sound/AudioVolumeScaler.cs
+++ b/src/Assets/Scripts/Sound/AudioVolumeScaler.cs
@@ -6,14 +6,21 @@ public class AudioVolumeScaler : MonoBehaviour
 {
     // âπó Ç…âûÇ∂ÇƒÉXÉPÅ[ÉãÇïœâªÇ≥ÇπÇÈ
     [SerializeField] private AudioCulcurator AC;
+    [SerializeField] private float changeVolume = 1.0f;
+
+    private Transform targetObject;
+    private Vector3 initialScale;
 
     void Start()
     {
-        
+        targetObject = this.transform;
+        initialScale = targetObject.localScale;
     }
 
     void Update()
     {
-        Debug.Log(AC.GetCurrentData().ToString());
+        float vol = AC.GetCurrentData() * changeVolume;
+        Vector3 scale = new Vector3(initialScale.x + vol, initialScale.y + vol, initialScale.z + vol);
+        targetObject.localScale = scale;
     }
 }

--- a/src/Assets/Scripts/Sound/AudioVolumeScaler.cs.meta
+++ b/src/Assets/Scripts/Sound/AudioVolumeScaler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8570b249ee2b7f44582fd59505f94179
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Scripts/Sound/SpectrumLineConrtrol.cs
+++ b/src/Assets/Scripts/Sound/SpectrumLineConrtrol.cs
@@ -1,0 +1,124 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SpectrumLineConrtrol : MonoBehaviour
+{
+    [SerializeField] private LineRenderer line;
+    [SerializeField] private AudioSource source = null;
+
+    private const int FFT_RESOLUSION = 256;
+
+    [SerializeField, Range(1, FFT_RESOLUSION)] private int visible = 128;
+    [SerializeField] private float waveLength = 20.0f;
+    [SerializeField] private float hight = 10.0f;
+    [SerializeField] private int bias = 1000;
+
+    private float[] spectrum = null;
+    private float[] data = null;
+    private int sampleStep = 0;
+    private Vector3[] points = null;
+    private Vector3[] samples = null;
+
+    void Start()
+    {
+        // スペクトラム用の配列の準備
+        spectrum = new float[FFT_RESOLUSION];
+
+        // 音量用データの配列
+        data = new float[source.clip.channels * source.clip.samples];
+        //Debug.Log("samples : " + source.clip.samples);
+        //Debug.Log("frequency : " + source.clip.frequency);
+        //Debug.Log("ratio : " + source.clip.samples / source.clip.frequency);
+        //Debug.Log("channels : " + source.clip.channels);
+        source.clip.GetData(data, 0); // 曲全部分のデータをここで格納
+        var fps = 1f / Time.fixedDeltaTime;
+        sampleStep = (int)(source.clip.channels * source.clip.frequency / fps);
+
+        //line.positionCount = data.Length/100;
+        //Vector3[] p = new Vector3[data.Length];
+        //for(int i = 0; i < p.Length; i+=100)
+        //{
+        //    p[i] = new Vector3(i / 3000, data[i] * hight, 0);
+        //}
+        //line.SetPositions(p);
+
+        // ラインレンダラーの制御用配列
+        points = new Vector3[FFT_RESOLUSION];
+        var step = waveLength / spectrum.Length;
+        for (int i = 0; i < FFT_RESOLUSION; i++)
+        {
+            points[i] = new Vector3(step * i, 0, 0); // 最初は直線の状態
+        }
+
+        samples = new Vector3[sampleStep];
+        step = waveLength / samples.Length;
+        for(int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = new Vector3(step * i, 0, 0);
+        }
+    }
+
+    void FixedUpdate()
+    {
+        SpectrumRender();
+        // WaveRender();
+    }
+
+    private void SpectrumRender()
+    {
+        source.GetSpectrumData(spectrum, 0, FFTWindow.BlackmanHarris);
+
+        var xStep = waveLength / spectrum.Length;
+
+        float sum = 0;
+        float[] buf = new float[5];
+        int bi = 0;
+        for(int i = 0; i < 5; i++)
+        {
+            buf[i] = 0;
+        }
+
+        for(int i = 0; i < FFT_RESOLUSION; i++)
+        {
+            sum -= buf[bi];
+            buf[bi] = spectrum[i];
+            sum += buf[bi++];
+            if (bi >= 5) bi = 0;
+
+            int isActive = visible >= i ? 1 : 0;
+
+            var y = (sum * hight / 5) * isActive;
+            var x = xStep * i;
+
+            points[i] = new Vector3(x, y, 0);
+        }
+
+        if(points == null)
+        {
+            return;
+        }
+        line.positionCount = points.Length;
+        line.SetPositions(points);
+    }
+
+    private void WaveRender()
+    {
+        int startIndex = source.timeSamples + bias;
+        // Debug.Log(startIndex / source.clip.frequency);
+        int endIndex = Mathf.Min(startIndex + sampleStep, data.Length);
+
+        int amount = Mathf.Max(endIndex - startIndex, 1);
+        float xStep = waveLength / amount;
+
+        for(int i = 0; i < amount; i += source.clip.channels)
+        {
+            var x = xStep * i;
+            var y = data[startIndex + i / source.clip.channels] * hight;
+            samples[i] = new Vector3(x, y, 0);
+        }
+
+        line.positionCount = amount;
+        line.SetPositions(samples);
+    }
+}

--- a/src/Assets/Scripts/Sound/SpectrumLineConrtrol.cs
+++ b/src/Assets/Scripts/Sound/SpectrumLineConrtrol.cs
@@ -61,8 +61,8 @@ public class SpectrumLineConrtrol : MonoBehaviour
 
     void FixedUpdate()
     {
-        SpectrumRender();
-        // WaveRender();
+        // SpectrumRender();
+        WaveRender();
     }
 
     private void SpectrumRender()

--- a/src/Assets/Scripts/Sound/SpectrumLineConrtrol.cs
+++ b/src/Assets/Scripts/Sound/SpectrumLineConrtrol.cs
@@ -35,14 +35,6 @@ public class SpectrumLineConrtrol : MonoBehaviour
         var fps = 1f / Time.fixedDeltaTime;
         sampleStep = (int)(source.clip.channels * source.clip.frequency / fps);
 
-        //line.positionCount = data.Length/100;
-        //Vector3[] p = new Vector3[data.Length];
-        //for(int i = 0; i < p.Length; i+=100)
-        //{
-        //    p[i] = new Vector3(i / 3000, data[i] * hight, 0);
-        //}
-        //line.SetPositions(p);
-
         // ラインレンダラーの制御用配列
         points = new Vector3[FFT_RESOLUSION];
         var step = waveLength / spectrum.Length;
@@ -65,6 +57,7 @@ public class SpectrumLineConrtrol : MonoBehaviour
         WaveRender();
     }
 
+    // スペクトルを表示
     private void SpectrumRender()
     {
         source.GetSpectrumData(spectrum, 0, FFTWindow.BlackmanHarris);
@@ -102,6 +95,7 @@ public class SpectrumLineConrtrol : MonoBehaviour
         line.SetPositions(points);
     }
 
+    // 波形データを表示
     private void WaveRender()
     {
         int startIndex = source.timeSamples + bias;

--- a/src/Assets/Scripts/Sound/SpectrumLineConrtrol.cs.meta
+++ b/src/Assets/Scripts/Sound/SpectrumLineConrtrol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab00fb87a38409442b089b27a739233d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
音に連動して動かすためのデータ受け渡しクラスと実装例の追加

## 変更点
- AudioCulcurator から波形データと現在の音量、スペクトルを受け渡せる
- 複数の AudioSource に対応
- LineRenderer でスペクトラムを表示する例の追加
- LineRenderer で波形を表示する例
- 音量に応じてスケールを変える例

## レビューしてほしいポイント
- List に配列を入れてるが初期化など正しいか
- ref を使った参照受け渡しを使ったが正しいか
- なんか最初の起動めっちゃ重い